### PR TITLE
update RealWorld example of Builder pattern

### DIFF
--- a/src/RefactoringGuru/Builder/RealWorld/index.php
+++ b/src/RefactoringGuru/Builder/RealWorld/index.php
@@ -158,8 +158,9 @@ class PostgresQueryBuilder extends MysqlQueryBuilder
      */
     public function limit(int $start, int $offset): SQLQueryBuilder
     {
-        parent::limit($start, $offset);
-
+        if (!in_array($this->query->type, ['select'])) {
+            throw new \Exception("LIMIT can only be added to SELECT");
+        }
         $this->query->limit = " LIMIT " . $start . " OFFSET " . $offset;
 
         return $this;


### PR DESCRIPTION
I think its better to repeat validation part instead of calling parent's method which does unnecessary steps beside validation.
And also it confused me and I scrolled back to see for what purpose parent's method called.

Overthinking:
Maybe we can extract validation part into some AbstractQueryBuilder as they are not part of syntax and probably that constraints are same for all SQL dialects.