### PR TITLE
Bug fixed in accessing static variable $instances.

### DIFF
--- a/src/RefactoringGuru/Singleton/Conceptual/index.php
+++ b/src/RefactoringGuru/Singleton/Conceptual/index.php
@@ -84,11 +84,11 @@ class Singleton
     public static function getInstance(): Singleton
     {
         $cls = static::class;
-        if (!isset(static::$instances[$cls])) {
-            static::$instances[$cls] = new static;
+        if (!isset(self::$instances[$cls])) {
+            self::$instances[$cls] = new static;
         }
 
-        return static::$instances[$cls];
+        return self::$instances[$cls];
     }
 
     /**


### PR DESCRIPTION
Static variable of parent class should be accessed by "self::"