### PR TITLE
Replace abstract class to an interface in the Interpreter pattern

### DIFF
--- a/src/RefactoringGuru/Interpreter/RealWorld/index.php
+++ b/src/RefactoringGuru/Interpreter/RealWorld/index.php
@@ -30,12 +30,12 @@ class Context
     }
 }
 
-abstract class AbstractExp
+interface Expression
 {
-    abstract public function interpret(Context $context): bool;
+    public function interpret(Context $context): bool;
 }
 
-class VariableExp extends AbstractExp
+class VariableExp implements Expression
 {
     private $name;
 
@@ -55,12 +55,12 @@ class VariableExp extends AbstractExp
     }
 }
 
-class AndExp extends AbstractExp
+class AndExp implements Expression
 {
     private $first;
     private $second;
 
-    public function __construct(AbstractExp $first, AbstractExp $second)
+    public function __construct(Expression $first, Expression $second)
     {
         $this->first  = $first;
         $this->second = $second;
@@ -72,12 +72,12 @@ class AndExp extends AbstractExp
     }
 }
 
-class OrExp extends AbstractExp
+class OrExp implements Expression
 {
     private $first;
     private $second;
 
-    public function __construct(AbstractExp $first, AbstractExp $second)
+    public function __construct(Expression $first, Expression $second)
     {
         $this->first  = $first;
         $this->second = $second;

--- a/src/RefactoringGuru/Interpreter/RealWorld/index.php
+++ b/src/RefactoringGuru/Interpreter/RealWorld/index.php
@@ -17,14 +17,14 @@ class Context
 
     public function lookUp(string $name): bool
     {
-        if (!key_exists($name, $this->poolVariable)) {
+        if (!array_key_exists($name, $this->poolVariable)) {
             die("No exist variable: $name");
         }
 
         return $this->poolVariable[$name];
     }
 
-    public function assign(VariableExp $variable, $val)
+    public function assign(VariableExp $variable, $val): void
     {
         $this->poolVariable[$variable->getName()] = $val;
     }
@@ -68,7 +68,7 @@ class AndExp implements Expression
 
     public function interpret(Context $context): bool
     {
-        return (bool)$this->first->interpret($context) && $this->second->interpret($context);
+        return $this->first->interpret($context) && $this->second->interpret($context);
     }
 }
 


### PR DESCRIPTION
Hi!

First of all thanks a lot for this great repository. I've found that here the `abstract` class `AbstractExp`  only has an abstract method so it can be replaced to an `interface`.

Thanks and let me know :) 