### PR TITLE
Visitor real-world example

### DIFF
--- a/src/RefactoringGuru/Visitor/RealWorld/Output.txt
+++ b/src/RefactoringGuru/Visitor/RealWorld/Output.txt
@@ -18,12 +18,34 @@ SuperStarDevelopment (USD550,000.00)
     $ 34,000.00 John Burnovsky (operator)
     $ 35,000.00 Sergey Korolev (operator)
 
-Client: ...or just for a single department:
 
-Tech Support (USD199,000.00)
+Client: ...or for different entities such as an employee, a department, or the whole company:
 
-    $ 70,000.00 Larry Ulbrecht (supervisor)
-    $ 30,000.00 Elton Pale (operator)
-    $ 30,000.00 Rajeet Kumar (operator)
-    $ 34,000.00 John Burnovsky (operator)
-    $ 35,000.00 Sergey Korolev (operator)
+35000 Some employee (operator)
+
+Tech Support (199000)
+
+   70000 Larry Ulbrecht (supervisor)
+   30000 Elton Pale (operator)
+   30000 Rajeet Kumar (operator)
+   34000 John Burnovsky (operator)
+   35000 Sergey Korolev (operator)
+
+SuperStarDevelopment (550000)
+
+--Mobile Development (351000)
+
+   100000 Albert Falmore (designer)
+   100000 Ali Halabay (programmer)
+   90000 Sarah Konor (programmer)
+   31000 Monica Ronaldino (QA engineer)
+   30000 James Smith (QA engineer)
+
+--Tech Support (199000)
+
+   70000 Larry Ulbrecht (supervisor)
+   30000 Elton Pale (operator)
+   30000 Rajeet Kumar (operator)
+   34000 John Burnovsky (operator)
+   35000 Sergey Korolev (operator)
+

--- a/src/RefactoringGuru/Visitor/RealWorld/index.php
+++ b/src/RefactoringGuru/Visitor/RealWorld/index.php
@@ -271,8 +271,13 @@ $report = new SalaryReport();
 echo "Client: I can print a report for a whole company:\n\n";
 echo $company->accept($report);
 
-echo "\nClient: ...or just for a single department:\n\n";
-echo $techSupport->accept($report);
+echo "\nClient: ...or for different entities " .
+    "such as an employee, a department, or the whole company:\n\n";
+$someEmployee = new Employee("Some employee", "operator", 35000);
+$differentEntities = [$someEmployee, $techSupport, $company];
+foreach ($differentEntities as $entity) {
+    echo $entity->accept($report) . "\r\n";
+}
 
 // $export = new JSONExport(); 
 // echo $company->accept($export);


### PR DESCRIPTION
Hello!

I think the Visitor real-world example could be more informative as to why this pattern exists.

I couldn't understand why instead of this
```php
echo "Client: I can print a report for a whole company:\n\n";
echo $company->accept($report);

echo "\nClient: ...or just for a single department:\n\n";
echo $techSupport->accept($report);
```

We couldn't use this:
```php
echo "Client: I can print a report for a whole company:\n\n";
echo $report->visitCompany($company);

echo "\nClient: ...or just for a single department:\n\n";
echo $report->visitDepartment($techSupport);
```

I think something like this gets the message more across:
```php
echo "\nClient: ...or for different entities "
    . "such as an employee, a department, or the whole company:\n\n";
$someEmployee = new Employee("Some employee", "operator", 35000);
$differentEntities = [$someEmployee, $techSupport, $company];
foreach ($differentEntities as $entity) {
    echo $entity->accept($report) . "\r\n";
}
```

The latter made it much clear to me why we'd need interfaces and the visitor pattern.
